### PR TITLE
build(release): bump version to 2.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,10 @@ Example: `feat(protection): add nightshade intensity control`
 - Effects: `$effect(() => { ... return cleanup; })`
 - No `<style>` blocks; all styling via Tailwind CSS utility classes
 
+### Styling (Tailwind CSS 4)
+
+- Use logical inset utilities for RTL-aware positioning: prefer `inset-e-*` (inline-end) and `inset-s-*` (inline-start) over `end-*` / `start-*`. Example: `inset-e-4`, not `end-4`.
+
 ### State Management
 
 - TanStack Svelte Query for server state (`createQuery`, `createMutation`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.3.0] - 2026-07-15
+
+### Security
+- Point the updater endpoint at the HopeArtOrg organization so update checks resolve to the correct release manifest.
+- Sanitize update release notes with DOMPurify before rendering to prevent HTML/script injection from the update manifest.
+- Remove the unused create_ort_session command, which accepted an arbitrary filesystem path from the webview.
+
+### Fixed
+- Prefill the extraction seed from the embed step so custom-seed watermark verification round-trips correctly.
+- Record the watermark signature length in UTF-8 bytes instead of UTF-16 code units so non-ASCII signatures verify correctly.
+- Guard against negative intensity and epsilon values that could panic the protection worker.
+- Add a re-entrancy guard to image protection, stop the progress listener before re-registering it, treat user cancellation as a non-error, and clear pending reset timers.
+- Keep both tabs mounted so an in-progress protection run survives switching tabs.
+- Add connection and read timeouts to model downloads, clean up temporary files on failure, and sweep stale temp files on start.
+- Save protected images with the correct file extension (jpeg vs png) based on the encoded output.
+- Fix macOS GPU detection parsing and the Android build by adding a cancel_protection stub and splitting the Linux and Android execution-provider configuration.
+- Make the theme store a singleton with a single system-theme listener, guard the file-upload race, reset fullscreen zoom on open, sync the window-control state, and add accessible labels to window and dialog controls.
+
+### Changed
+- Rename the ResourceDownloadGuard props type to ResourceDownloadGuardProps for consistency with other components.
+- Use the logical inset-e-4 utility instead of end-4, and document the Tailwind CSS 4 inset-e-* and inset-s-* convention in AGENTS.md.
+- Narrow the accepted image MIME types to png, jpeg, and webp, and disable native drag-and-drop so HTML5 drop works across platforms.
+- Bump version to 2.3.0 across package.json, Cargo.toml, and tauri.conf.json.
+
+### Removed
+- Remove unused UI component families (tabs, badge, switch), dead store members, the VerificationStatus barrel re-export, and the non-functional watermark strength slider.
+- Remove the unused @fontsource/be-vietnam-pro dependency.
+
+### Added
+- Add the dompurify dependency for update-notes sanitization.
+
 ## [2.2.3] - 2026-07-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-re",
   "type": "module",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2283,7 +2283,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-ad"
-version = "2.2.3"
+version = "2.3.0"
 dependencies = [
  "base64 0.22.1",
  "blind_watermark",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-ad"
-version = "2.2.3"
+version = "2.3.0"
 description = "An AI-proofing arts app"
 authors = [ "HopeArtOrg" ]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope-RE",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "identifier": "com.HopeArtOrg.hope-re",
   "build": {
     "frontendDist": "../build",

--- a/src/lib/components/main/resource-download/resource-download-guard.svelte
+++ b/src/lib/components/main/resource-download/resource-download-guard.svelte
@@ -11,11 +11,11 @@
   import { useModelDownload } from "$lib/stores/use-model-download.svelte";
   import { cn } from "$lib/utils";
 
-  type Props = {
+  type ResourceDownloadGuardProps = {
     children: Snippet;
   };
 
-  const { children }: Props = $props();
+  const { children }: ResourceDownloadGuardProps = $props();
 
   const models = useModelDownload();
   let mounted = $state<boolean>(false);
@@ -68,7 +68,7 @@
     {#if models.isDownloading}
       <button
         onclick={() => models.minimize()}
-        class="absolute end-4 top-4 rounded-lg opacity-50 transition-opacity hover:opacity-100 focus-visible:outline-hidden cursor-pointer"
+        class="absolute inset-e-4 top-4 rounded-lg opacity-50 transition-opacity hover:opacity-100 focus-visible:outline-hidden cursor-pointer"
         aria-label="Minimize to dock"
       >
         <MinusIcon class="size-4" />


### PR DESCRIPTION
Follow-up to #91 (merged into `fable5-fixes`). Small convention fixes plus the version bump and changelog.

## Changes
- **Rename** the `ResourceDownloadGuard` props type `Props` → `ResourceDownloadGuardProps`, matching the `<Component>Props` convention used elsewhere.
- **Tailwind:** use the logical `inset-e-4` utility instead of `end-4` in `resource-download-guard.svelte` (identical CSS — `inset-inline-end` — consistent with `update-dialog.svelte`).
- **Docs:** document the Tailwind CSS 4 `inset-e-*` / `inset-s-*` convention in `AGENTS.md`.
- **Version:** bump to `2.3.0` across `package.json`, `Cargo.toml`, `Cargo.lock`, and `tauri.conf.json`.
- **Changelog:** add the `2.3.0` entry summarizing this release (the merged #91 fixes plus the above).

## Verification
svelte-check 0/0, eslint clean, `pnpm build` passes (confirms `inset-e-4` generates `inset-inline-end`), cargo fmt clean.