### PR TITLE
style(header): match language selector to the neighboring header buttons

### DIFF
--- a/src/lib/components/header/language-select.svelte
+++ b/src/lib/components/header/language-select.svelte
@@ -2,7 +2,9 @@
   import type { Locale } from "$lib/i18n";
 
   import { LanguagesIcon } from "@lucide/svelte";
+  import { Select as SelectPrimitive } from "bits-ui";
 
+  import { Button } from "$lib/components/ui/button";
   import * as Select from "$lib/components/ui/select";
   import { locales } from "$lib/i18n";
   import { t, useI18n } from "$lib/stores/use-i18n.svelte";
@@ -10,7 +12,6 @@
   const i18n = useI18n();
 
   const value = $derived(i18n.getLocale());
-  const currentLabel = $derived(locales.find(item => item.value === value)?.label ?? "English");
 
   function handleChange(newValue: string) {
     i18n.setLocale(newValue as Locale);
@@ -20,14 +21,19 @@
 <Select.Root type="single"
              {value}
              onValueChange={handleChange}>
-  <Select.Trigger
-    size="sm"
-    class="w-auto gap-2 bg-white/40 dark:bg-black/40 hover:bg-white/60 dark:hover:bg-black/60 border-foreground/10 shadow-sm"
-    aria-label={t("header.language")}
-  >
-    <LanguagesIcon class="size-4 shrink-0" />
-    <span class="font-bold">{currentLabel}</span>
-  </Select.Trigger>
+  <SelectPrimitive.Trigger>
+    {#snippet child({ props })}
+      <Button
+        {...props}
+        variant="outline"
+        size="sm"
+        class="flex items-center gap-2 px-3 py-2 doodle-blob border-2 border-foreground/10 bg-white/40 dark:bg-black/40 hover:bg-white/60 dark:hover:bg-black/60 hover:cursor-pointer transition-all shadow-sm"
+        aria-label={t("header.language")}
+      >
+        <LanguagesIcon class="size-4" />
+      </Button>
+    {/snippet}
+  </SelectPrimitive.Trigger>
   <Select.Content class="min-w-[8rem]">
     {#each locales as item (item.value)}
       <Select.Item value={item.value} label={item.label} />


### PR DESCRIPTION
## Summary

Follow-up to #94. Restyles the header language switcher so it visually matches its neighboring header controls (theme toggle, system info, update).

- Renders the trigger as an icon-only `outline` `Button` (via a bits-ui `child` snippet) with the same `doodle-blob` shape, border, background, hover, and shadow as the sibling buttons.
- Drops the visible locale label and the select chevron so it belongs with the icon-only neighbors; the dropdown still lists all locales with the active one checked.

Single-file change (`language-select.svelte`). `svelte-check`, ESLint, and the production build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
