### PR TITLE
build(release): bump version to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.4.0] - 2026-07-15
+
+### Added
+- Add in-app language switching with full UI localization for English, Vietnamese, Japanese, and Chinese.
+
 ## [2.3.0] - 2026-07-15
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-re",
   "type": "module",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2283,7 +2283,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-ad"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "base64 0.22.1",
  "blind_watermark",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-ad"
-version = "2.3.0"
+version = "2.4.0"
 description = "An AI-proofing arts app"
 authors = [ "HopeArtOrg" ]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope-RE",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "identifier": "com.HopeArtOrg.hope-re",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Summary

Bump the application version from 2.3.0 to 2.4.0.

- Update the version across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock` (`hope-ad`), and `src-tauri/tauri.conf.json`.
- Add a `[2.4.0]` CHANGELOG entry for the new in-app language switching / full UI localization (English, Vietnamese, Japanese, Chinese).

_Note: the `Cargo.lock` `hope-ad` entry was updated by hand to match; `cargo check` was not run in this environment._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
