### PR TITLE
build(release): tag-driven releases, documentation restructure, and version 2.5.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: publish
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 jobs:
   publish-tauri:
@@ -76,7 +76,7 @@ jobs:
       - name: Get Version
         id: get_version
         shell: bash
-        run: echo "VERSION=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Get Release Notes
         id: release_notes
@@ -104,8 +104,8 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: __VERSION__
-          releaseName: Hope v__VERSION__
+          tagName: ${{ github.ref_name }}
+          releaseName: Hope ${{ github.ref_name }}
           releaseBody: ${{ steps.release_notes.outputs.BODY }}
           releaseDraft: false
           prerelease: false
@@ -128,11 +128,9 @@ jobs:
       - name: Pull LFS objects
         run: git lfs pull
 
-      - name: Read version from tauri.conf.json
+      - name: Resolve release tag
         id: version
-        run: |
-          TAG="$(jq -r '.version' src-tauri/tauri.conf.json)"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        run: echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Validate ONNX files are real binaries
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,255 +5,27 @@ Frontend: SvelteKit 2 + Svelte 5 + TypeScript + Tailwind CSS 4 + shadcn-svelte.
 Backend: Rust (Tauri v2) with ONNX Runtime ML inference.
 Design philosophy: minimalistic artistic Japanese Zen-like system design.
 
-## Build / Dev / Lint Commands
-
-```bash
-pnpm install              # install frontend dependencies
-pnpm dev                  # start Vite dev server (port 3000)
-pnpm build                # production build (Vite SSG)
-pnpm lint                 # ESLint check (strict, replaces Prettier)
-pnpm format               # ESLint auto-fix
-pnpm check                # svelte-kit sync + svelte-check (type checking)
-pnpm check:watch          # same with --watch
-pnpm tauri dev             # full desktop app dev (Rust + frontend)
-pnpm tauri build           # production desktop build
-```
-
-Rust backend (run from `src-tauri/`):
-
-```bash
-cargo build               # build Rust backend
-cargo check               # type check only
-cargo clippy               # lint Rust code
-cargo fmt                  # format Rust code (rustfmt)
-```
-
-## Testing
-
-No test framework is currently configured. There are no test files in the repo.
-If adding tests, use `vitest` for frontend and `cargo test` for Rust.
-
-## Pre-commit Hooks
-
-Husky runs `lint-staged` on pre-commit which executes `pnpm lint` on all staged files.
-Always run `pnpm lint` before committing.
-
-## Commit Convention
-
-Angular-style conventional commits. Format: `<type>(<scope>): <subject>`
-
-Types: `feat`, `fix`, `perf` (appear in changelog), `build`, `ci`, `docs`, `style`, `refactor`, `test`.
-Subject: imperative present tense, no capital first letter, no trailing period.
-Example: `feat(protection): add nightshade intensity control`
-
-## Code Style - TypeScript / Svelte
-
-### Formatting (enforced by ESLint, Prettier is disabled)
-
-- 2 spaces indent
-- Semicolons always
-- Double quotes
-- Max 2 attributes per line (single-line Svelte), 1 per line (multi-line)
-
-### File Naming
-
-- **kebab-case** for all `.ts`, `.svelte`, `.css` files (enforced by ESLint)
-- Rust files use **snake_case** (excluded from kebab-case rule)
-- Stores: `use-*.svelte.ts` pattern
-- Component directories: `index.svelte` as entry, `index.ts` for barrel exports
-
-### Type Definitions
-
-- Always use `type` keyword, never `interface` (enforced: `ts/consistent-type-definitions`)
-- Always use `import type` for type-only imports
-- Export types from co-located `types.ts` files, re-export through barrel `index.ts`
-- PascalCase for type names: `ProtectionSettings`, `AlgorithmParams`
-
-### Import Order (enforced by `perfectionist/sort-imports`)
-
-1. `import type { ... }` (type-only, separated by blank line)
-2. External packages (`@lucide`, `@tanstack`, `@tauri-apps`, `svelte-sonner`, etc.)
-3. Internal `$lib/...` imports
-4. Relative imports (`./types`, `../utils`)
-
-### Naming Conventions
-
-- Variables/functions: `camelCase`
-- Event handlers: `handle*` prefix (`handleProtect`, `handleDownload`)
-- Hooks/stores: `use*` prefix (`useImage`, `useProtection`)
-- Types: `PascalCase`
-- Constants (scalars): `UPPER_SNAKE_CASE` (`TILE_SIZE`, `SUCCESS_RESET_MS`)
-- Constants (arrays/objects): `camelCase` (`algorithms`, `qualityPresets`)
-- Components: PascalCase in exports, kebab-case filenames
-
-### Svelte 5 Runes (mandatory, no legacy syntax)
-
-- Props: `$props()` with destructuring and defaults; `$bindable()` for two-way
-- State: `$state<T>()` with explicit generic type
-- Derived: `$derived(expression)`
-- Effects: `$effect(() => { ... return cleanup; })`
-- No `<style>` blocks; all styling via Tailwind CSS utility classes
-
-### Styling (Tailwind CSS 4)
-
-- Use logical inset utilities for RTL-aware positioning: prefer `inset-e-*` (inline-end) and `inset-s-*` (inline-start) over `end-*` / `start-*`. Example: `inset-e-4`, not `end-4`.
-
-### State Management
-
-- TanStack Svelte Query for server state (`createQuery`, `createMutation`)
-- Svelte 5 rune-based composables for local state (`use-*.svelte.ts`)
-- Expose reactive state via getters/setters in returned objects (preserves reactivity)
-- Module-level `$state` for singleton stores, function-level for instance stores
-
-### Internationalization (i18n)
-
-- Supported locales: English (`en`), Vietnamese (`vi`), Japanese (`ja`), Chinese (`zh`).
-- No i18n library. `lib/i18n/locales/en.ts` is the source of truth and exports
-  `type Messages = typeof en`; `vi`/`ja`/`zh` are typed `Messages`, so `pnpm check`
-  fails if any locale drifts out of key-sync. Add every new key to all four files.
-- Never hardcode user-facing text (template nodes, `placeholder`/`title`/`aria-label`,
-  `toast.*`, `sr-only`, progress messages). Use `t("dot.path")` from
-  `$lib/stores/use-i18n.svelte`; it is reactive in `.svelte` and callable in `.svelte.ts`.
-- Interpolate with `{name}` tokens: `t("image.loaded", { name })`. Unknown keys return
-  the key; a locale missing a key falls back to English.
-- Structural constants (`algorithms`, `glazeStyles`, `nightshadeTargets`, `qualityPresets`)
-  hold only `value`/`key`/icons/colours; their labels/descriptions live in the dictionaries,
-  keyed by `value`/`key` (e.g. algorithm labels resolve via `algorithms.<value>.label`).
-- Locale is persisted to `settings.json` (via `useI18n().setLocale`), detected from
-  `navigator.language` on first run, and switched from the header `LanguageSelect`.
-- Decorative, non-informational marks stay untranslated (brand `Hope:RE`, calligraphy
-  stamps `落款`/`印章`/`証`/`未`, the `ERASE` doodle).
-- CJK glyphs are covered by system-font fallbacks appended to `--font-patrick-hand` in
-  `app.css` (Patrick Hand has no CJK coverage).
-
-### Error Handling (TypeScript)
-
-- Wrap in `try/catch`, call `toast.error("message")` + `console.error("context:", error)`
-- Extract messages: `e instanceof Error ? e.message : String(e)`
-- `else` and `catch` on new line after closing brace (Allman-ish style)
-
-### Comments and Emojis
-
-- **No comments in code.** Do not add inline comments, block comments, or JSDoc to TypeScript,
-  Svelte, or Rust files. The code should be self-documenting through clear naming.
-- **No emojis in markdown or code.** Never use emoji characters in `.md` files, commit messages,
-  toast messages, log messages, or anywhere else in the codebase.
-
-### Restricted Patterns
-
-- `no-console`: warn (prefer toast for user-facing messages)
-- `node/no-process-env`: error (use Tauri APIs instead)
-- `antfu/no-top-level-await`: off (allowed)
-
-## Code Style - Rust
-
-### Formatting (`rustfmt.toml`)
-
-- Edition 2021, max width 100, 4 spaces, Unix newlines
-
-### Module Organization
-
-- `mod.rs` declares submodules and re-exports public API via `pub use`
-- Private submodules: `mod name;` (no `pub`)
-- Files: **snake_case**; Types: **PascalCase**; Constants: **UPPER_SNAKE_CASE**
-
-### Tauri Commands
-
-- Annotated with `#[tauri::command]`, always return `Result<T, String>`
-- Errors via `.map_err(|e| format!("Descriptive message: {}", e))?`
-- No custom error enums; all errors are `String`-typed
-- Non-critical event emissions: `let _ = app.emit(...);`
-
-### Structs
-
-- Derive `Debug, Clone, serde::Serialize, serde::Deserialize` for data transfer types
-- Use `Option<T>` for optional fields
-
-### Platform-Specific Code
-
-- Use `#[cfg(...)]` for conditional compilation (CUDA/DirectML/CoreML/XNNPACK)
-- Stubs in `onnx_stubs.rs` for unsupported platforms
-
-### Logging
-
-- Use `log::info!`, `log::error!`, etc. (via Tauri log plugin)
-
-## Project Structure
-
-```
-src/                      # Frontend (SvelteKit + Svelte 5)
-  lib/components/         # UI components (shadcn-svelte based)
-  lib/queries/            # TanStack Query hooks (by domain)
-  lib/stores/             # Svelte 5 rune composables (use-*.svelte.ts)
-  lib/i18n/               # Message dictionaries (en/vi/ja/zh) + Messages type
-  lib/constants.ts        # Algorithm/style/preset definitions
-  lib/utils.ts            # cn(), parseMarkdown, type helpers
-  routes/                 # SvelteKit routes (SPA, SSR disabled)
-src-tauri/                # Backend (Rust / Tauri v2)
-  src/commands/           # Tauri command handlers
-  src/onnx_integration/   # ONNX Runtime: models, protection pipeline
-  src/system_info/        # System info gathering (CPU, GPU, memory)
-src-models/               # ML training (Python/JAX notebooks, ONNX export)
-```
-
-## Key Dependencies
-
-Frontend: `@tauri-apps/api`, `@tanstack/svelte-query`, `bits-ui`, `tailwind-merge`,
-`clsx`, `svelte-sonner`, `marked`, `mode-watcher`, `lucide-svelte`.
-Backend: `tauri` 2.x, `ort` (ONNX Runtime), `image`, `ndarray`, `reqwest`, `sysinfo`.
-
-## CI/CD
-
-- PR lint: `pnpm lint` on Ubuntu (Node 24, pnpm 10)
-- Release: multi-platform Tauri build (macOS ARM, Windows x64, Linux amd64/arm64)
-- ONNX models tracked via Git LFS, uploaded to GitHub Releases
-
-## ONNX Model Pipeline
-
-### Model Architecture
-
-Three ONNX models (~350MB each) built on ViT-B/32 CLIP:
-
-- `noise_algorithm.onnx` -- Adversarial noise (input: image only)
-- `glaze_algorithm.onnx` -- Style cloaking (input: image + style_index 0-4)
-- `nightshade_algorithm.onnx` -- Data poisoning (input: image + target_index 0-7)
-
-All models: NHWC `(1, 224, 224, 3)` float32 in `[0.0, 1.0]`, scalar float32 loss output.
-CLIP normalization is baked into the model graph.
-
-### Training Pipeline (Google Colab)
-
-```
-0_setup_colab.ipynb    -> GPU check, JAX+CUDA install
-1_clip_to_jax.ipynb    -> PyTorch CLIP -> numpy weights, pre-compute text embeddings
-2_noise_algorithm.ipynb -> JAX noise model -> .pkl
-3_glaze_algorithm.ipynb -> JAX glaze model -> .pkl
-4_nightshade_algorithm.ipynb -> JAX nightshade model -> .pkl
-5_export_onnx.ipynb    -> .pkl -> ONNX (jax2onnx, onnxsim, validate)
-```
-
-### Model Distribution Flow
-
-1. Train in Colab, export `.onnx` to `src-models/models/`
-2. Track with Git LFS (`.gitattributes`)
-3. `publish.yml` uploads to GitHub Release after Tauri build
-4. App downloads at runtime via `model_downloader.rs`
-5. Stored in `app_data_dir/models/`
-
-### Inference Pipeline (Rust)
-
-```
-Image -> base64 decode -> tile (224x224, overlap 32px)
-  -> preprocess (normalize to [0,1]) -> edge weight map
-  -> SPSA-PGD optimization (8 directions/iter, momentum 0.85)
-  -> blend tiles -> encode output
-```
-
-### Config Reference
-
-`src-models/models/hope_config.json` -- input specs, algorithm parameters, presets,
-Glaze styles (Abstract/Impressionist/Cubist/Sketch/Watercolor),
-Nightshade targets (Dog/Cat/Car/Landscape/Person/Building/Food/Abstract).
+## Documentation Map
+
+The project documentation is split into five feature documents. Read the relevant one before starting work; this file only keeps the agent-specific tooling and a digest of the non-negotiable rules.
+
+| Document                                     | Read it for                                                                                                        |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| [CODEBASE.md](CODEBASE.md)                   | Architecture: project structure, key dependencies, and the ONNX model pipeline (training, distribution, inference) |
+| [CORE_FUNCTION.md](CORE_FUNCTION.md)         | Features: the Tauri command surface and how protection, watermarking, models, updates, and system info flow        |
+| [CODING_CONVENTION.md](CODING_CONVENTION.md) | Code style: TypeScript/Svelte and Rust conventions, naming, imports, runes, state management, i18n rules           |
+| [CONTRIBUTE.md](CONTRIBUTE.md)               | Workflow: build/dev/lint commands, testing, pre-commit hooks, commit convention, CI/CD, and the release flow       |
+| [CI_CD_PIPELINE.md](CI_CD_PIPELINE.md)       | Pipelines: the lint gate, the tag-driven release build matrix, model upload, and required secrets                  |
+
+## Non-negotiable Rules
+
+The complete standards live in [CODING_CONVENTION.md](CODING_CONVENTION.md); these are the ones agents most often get wrong:
+
+- No comments in code (TypeScript, Svelte, or Rust) and no emojis anywhere (markdown, commits, toasts, logs).
+- kebab-case filenames for `.ts`/`.svelte`/`.css`; snake_case for Rust.
+- Svelte 5 runes only (`$props`, `$state`, `$derived`, `$effect`); no legacy syntax, no `<style>` blocks.
+- All user-facing text goes through `t("dot.path")` from `$lib/stores/use-i18n.svelte`; every new key is added to all four locale dictionaries (`en`/`vi`/`ja`/`zh`).
+- Always run `pnpm lint` before committing; conventional commits (`<type>(<scope>): <subject>`).
 
 ## OpenCode Skills and Agents
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.5.0] - 2026-07-15
+
+### Added
+- Add CODEBASE.md documenting the architecture, project structure, key dependencies, and the ONNX model pipeline.
+- Add CODING_CONVENTION.md documenting the TypeScript, Svelte, i18n, and Rust coding standards.
+- Add CONTRIBUTE.md documenting setup commands, testing, pre-commit hooks, the commit convention, CI/CD, and the tag-driven release flow.
+- Add CI_CD_PIPELINE.md documenting the lint gate, the tag-driven release build matrix, the model upload job, and required secrets.
+- Add CORE_FUNCTION.md documenting the Tauri command surface and the protection, watermarking, model management, update, and system info flows.
+
+### Changed
+- Restructure AGENTS.md into a documentation hub that features CODEBASE.md, CODING_CONVENTION.md, and CONTRIBUTE.md alongside the agent skill guides.
+- Bump version to 2.5.0 across package.json, Cargo.toml, and tauri.conf.json.
+
 ## [2.4.0] - 2026-07-15
 
 ### Added

--- a/CI_CD_PIPELINE.md
+++ b/CI_CD_PIPELINE.md
@@ -1,0 +1,67 @@
+# Hope:RE - CI/CD Pipeline
+
+Reference for the GitHub Actions pipelines: what runs, when, and what they produce. For the step-by-step release procedure see [CONTRIBUTE.md](CONTRIBUTE.md); for what the released app does at runtime see [CORE_FUNCTION.md](CORE_FUNCTION.md).
+
+## Workflows
+
+| Workflow                        | Trigger                             | Purpose                                            |
+| ------------------------------- | ----------------------------------- | -------------------------------------------------- |
+| `.github/workflows/lint.yml`    | Pull request into `main`            | Lint gate (`pnpm lint`)                            |
+| `.github/workflows/publish.yml` | Push of a version tag matching `v*` | Multi-platform build, GitHub release, model upload |
+
+## Lint Pipeline (`lint.yml`)
+
+Runs on every pull request into `main`:
+
+1. Checkout.
+2. Node.js 24 and pnpm 11.11.0 (with cache).
+3. `pnpm install --frozen-lockfile`.
+4. `pnpm lint` (strict ESLint; it replaces Prettier and also covers JSON, YAML, and Markdown).
+
+The same check runs locally before every commit: Husky's pre-commit hook executes `lint-staged`, which runs `pnpm lint` on staged files.
+
+## Release Pipeline (`publish.yml`)
+
+Triggered by pushing a semver tag such as `v2.5.0`. Releases are driven by tags, not by pushes to `main`.
+
+### Job: `publish-tauri`
+
+Build matrix:
+
+| Runner                | Target                 |
+| --------------------- | ---------------------- |
+| `macos-latest`        | `aarch64-apple-darwin` |
+| `windows-2025-vs2026` | Windows x86_64         |
+| `ubuntu-24.04`        | Linux amd64            |
+| `ubuntu-24.04-arm`    | Linux arm64            |
+
+Each matrix leg:
+
+1. Checkout, Node.js 24, pnpm 11.11.0, stable Rust (plus the macOS ARM target); Linux legs install the WebKitGTK/GTK system dependencies.
+2. `pnpm install`.
+3. Derives the version from the tag (`v2.5.0` becomes `2.5.0`).
+4. Extracts the release notes from the matching `## [2.5.0]` section of `CHANGELOG.md` (falls back to a generic body if the section is missing).
+5. `tauri-apps/tauri-action` builds the bundles and creates (or updates) the GitHub release named `Hope v2.5.0` on the pushed tag, uploading the installers and the signed updater artifacts (`latest.json`, NSIS-preferred on Windows).
+
+### Job: `upload-models`
+
+Runs after all `publish-tauri` legs succeed:
+
+1. Checkout with Git LFS and pull the LFS objects.
+2. Validate that every `src-models/models/*.onnx` is a real binary, not an LFS pointer file.
+3. `gh release upload` attaches the ONNX models to the same tag's release.
+
+The desktop app later downloads these models at first run; see [CORE_FUNCTION.md](CORE_FUNCTION.md).
+
+## Required Secrets
+
+| Secret                               | Used for                                             |
+| ------------------------------------ | ---------------------------------------------------- |
+| `GITHUB_TOKEN`                       | Creating the release and uploading assets (built in) |
+| `TAURI_SIGNING_PRIVATE_KEY`          | Signing the updater artifacts                        |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | Unlocking the signing key                            |
+
+## Versioning Rules
+
+- Semantic versioning; the `v*` tag is the single release trigger.
+- The tag must match the version embedded in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json`, and a matching `CHANGELOG.md` section must exist. The full checklist lives in [CONTRIBUTE.md](CONTRIBUTE.md).

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -1,0 +1,79 @@
+# Hope:RE - Codebase Guide
+
+AI art protection desktop app (adversarial perturbation via ONNX models).
+Frontend: SvelteKit 2 + Svelte 5 + TypeScript + Tailwind CSS 4 + shadcn-svelte.
+Backend: Rust (Tauri v2) with ONNX Runtime ML inference.
+Design philosophy: minimalistic artistic Japanese Zen-like system design.
+
+This document covers the architecture: how the repository is laid out, what the app depends on, and how the ONNX model pipeline works end to end. For feature-level behavior and the Tauri command surface see [CORE_FUNCTION.md](CORE_FUNCTION.md); for code style see [CODING_CONVENTION.md](CODING_CONVENTION.md); for setup, workflow, and releases see [CONTRIBUTE.md](CONTRIBUTE.md).
+
+## Project Structure
+
+```
+src/                      # Frontend (SvelteKit + Svelte 5)
+  lib/components/         # UI components (shadcn-svelte based)
+  lib/queries/            # TanStack Query hooks (by domain)
+  lib/stores/             # Svelte 5 rune composables (use-*.svelte.ts)
+  lib/i18n/               # Message dictionaries (en/vi/ja/zh) + Messages type
+  lib/constants.ts        # Algorithm/style/preset definitions
+  lib/utils.ts            # cn(), parseMarkdown, type helpers
+  routes/                 # SvelteKit routes (SPA, SSR disabled)
+src-tauri/                # Backend (Rust / Tauri v2)
+  src/commands/           # Tauri command handlers
+  src/onnx_integration/   # ONNX Runtime: models, protection pipeline
+  src/system_info/        # System info gathering (CPU, GPU, memory)
+src-models/               # ML training (Python/JAX notebooks, ONNX export)
+```
+
+## Key Dependencies
+
+Frontend: `@tauri-apps/api`, `@tanstack/svelte-query`, `bits-ui`, `tailwind-merge`,
+`clsx`, `svelte-sonner`, `marked`, `mode-watcher`, `lucide-svelte`.
+Backend: `tauri` 2.x, `ort` (ONNX Runtime), `image`, `ndarray`, `reqwest`, `sysinfo`.
+
+## ONNX Model Pipeline
+
+### Model Architecture
+
+Three ONNX models (~350MB each) built on ViT-B/32 CLIP:
+
+- `noise_algorithm.onnx` -- Adversarial noise (input: image only)
+- `glaze_algorithm.onnx` -- Style cloaking (input: image + style_index 0-4)
+- `nightshade_algorithm.onnx` -- Data poisoning (input: image + target_index 0-7)
+
+All models: NHWC `(1, 224, 224, 3)` float32 in `[0.0, 1.0]`, scalar float32 loss output.
+CLIP normalization is baked into the model graph.
+
+### Training Pipeline (Google Colab)
+
+```
+0_setup_colab.ipynb    -> GPU check, JAX+CUDA install
+1_clip_to_jax.ipynb    -> PyTorch CLIP -> numpy weights, pre-compute text embeddings
+2_noise_algorithm.ipynb -> JAX noise model -> .pkl
+3_glaze_algorithm.ipynb -> JAX glaze model -> .pkl
+4_nightshade_algorithm.ipynb -> JAX nightshade model -> .pkl
+5_export_onnx.ipynb    -> .pkl -> ONNX (jax2onnx, onnxsim, validate)
+```
+
+### Model Distribution Flow
+
+1. Train in Colab, export `.onnx` to `src-models/models/`
+2. Track with Git LFS (`.gitattributes`)
+3. `publish.yml` uploads to GitHub Release after Tauri build
+4. App downloads at runtime via `model_downloader.rs`
+5. Stored in `app_data_dir/models/`
+
+### Inference Pipeline (Rust)
+
+```
+Image -> base64 decode -> tile (224x224, overlap 32px)
+  -> preprocess (normalize to [0,1]) -> edge weight map
+  -> SPSA-PGD optimization (8 directions/iter, momentum 0.85)
+  -> blend tiles -> encode output
+```
+
+### Config Reference
+
+`src-models/models/hope_config.json` -- input specs, algorithm parameters, presets,
+Glaze styles (Abstract/Impressionist/Cubist/Sketch/Watercolor),
+Nightshade targets (Dog/Cat/Car/Landscape/Person/Building/Food/Abstract).

--- a/CODING_CONVENTION.md
+++ b/CODING_CONVENTION.md
@@ -1,0 +1,135 @@
+# Hope:RE - Coding Conventions
+
+Code style standards for the TypeScript/Svelte frontend and the Rust backend. Most of these are enforced by ESLint (frontend) and rustfmt/clippy (backend); the rest are project conventions that reviews hold the line on. For architecture see [CODEBASE.md](CODEBASE.md); for setup, workflow, and releases see [CONTRIBUTE.md](CONTRIBUTE.md).
+
+## Code Style - TypeScript / Svelte
+
+### Formatting (enforced by ESLint, Prettier is disabled)
+
+- 2 spaces indent
+- Semicolons always
+- Double quotes
+- Max 2 attributes per line (single-line Svelte), 1 per line (multi-line)
+
+### File Naming
+
+- **kebab-case** for all `.ts`, `.svelte`, `.css` files (enforced by ESLint)
+- Rust files use **snake_case** (excluded from kebab-case rule)
+- Stores: `use-*.svelte.ts` pattern
+- Component directories: `index.svelte` as entry, `index.ts` for barrel exports
+
+### Type Definitions
+
+- Always use `type` keyword, never `interface` (enforced: `ts/consistent-type-definitions`)
+- Always use `import type` for type-only imports
+- Export types from co-located `types.ts` files, re-export through barrel `index.ts`
+- PascalCase for type names: `ProtectionSettings`, `AlgorithmParams`
+
+### Import Order (enforced by `perfectionist/sort-imports`)
+
+1. `import type { ... }` (type-only, separated by blank line)
+2. External packages (`@lucide`, `@tanstack`, `@tauri-apps`, `svelte-sonner`, etc.)
+3. Internal `$lib/...` imports
+4. Relative imports (`./types`, `../utils`)
+
+### Naming Conventions
+
+- Variables/functions: `camelCase`
+- Event handlers: `handle*` prefix (`handleProtect`, `handleDownload`)
+- Hooks/stores: `use*` prefix (`useImage`, `useProtection`)
+- Types: `PascalCase`
+- Constants (scalars): `UPPER_SNAKE_CASE` (`TILE_SIZE`, `SUCCESS_RESET_MS`)
+- Constants (arrays/objects): `camelCase` (`algorithms`, `qualityPresets`)
+- Components: PascalCase in exports, kebab-case filenames
+
+### Svelte 5 Runes (mandatory, no legacy syntax)
+
+- Props: `$props()` with destructuring and defaults; `$bindable()` for two-way
+- State: `$state<T>()` with explicit generic type
+- Derived: `$derived(expression)`
+- Effects: `$effect(() => { ... return cleanup; })`
+- No `<style>` blocks; all styling via Tailwind CSS utility classes
+
+### Styling (Tailwind CSS 4)
+
+- Use logical inset utilities for RTL-aware positioning: prefer `inset-e-*` (inline-end) and `inset-s-*` (inline-start) over `end-*` / `start-*`. Example: `inset-e-4`, not `end-4`.
+
+### State Management
+
+- TanStack Svelte Query for server state (`createQuery`, `createMutation`)
+- Svelte 5 rune-based composables for local state (`use-*.svelte.ts`)
+- Expose reactive state via getters/setters in returned objects (preserves reactivity)
+- Module-level `$state` for singleton stores, function-level for instance stores
+
+### Internationalization (i18n)
+
+- Supported locales: English (`en`), Vietnamese (`vi`), Japanese (`ja`), Chinese (`zh`).
+- No i18n library. `lib/i18n/locales/en.ts` is the source of truth and exports
+  `type Messages = typeof en`; `vi`/`ja`/`zh` are typed `Messages`, so `pnpm check`
+  fails if any locale drifts out of key-sync. Add every new key to all four files.
+- Never hardcode user-facing text (template nodes, `placeholder`/`title`/`aria-label`,
+  `toast.*`, `sr-only`, progress messages). Use `t("dot.path")` from
+  `$lib/stores/use-i18n.svelte`; it is reactive in `.svelte` and callable in `.svelte.ts`.
+- Interpolate with `{name}` tokens: `t("image.loaded", { name })`. Unknown keys return
+  the key; a locale missing a key falls back to English.
+- Structural constants (`algorithms`, `glazeStyles`, `nightshadeTargets`, `qualityPresets`)
+  hold only `value`/`key`/icons/colours; their labels/descriptions live in the dictionaries,
+  keyed by `value`/`key` (e.g. algorithm labels resolve via `algorithms.<value>.label`).
+- Locale is persisted to `settings.json` (via `useI18n().setLocale`), detected from
+  `navigator.language` on first run, and switched from the header `LanguageSelect`.
+- Decorative, non-informational marks stay untranslated (brand `Hope:RE`, calligraphy
+  stamps `落款`/`印章`/`証`/`未`, the `ERASE` doodle).
+- CJK glyphs are covered by system-font fallbacks appended to `--font-patrick-hand` in
+  `app.css` (Patrick Hand has no CJK coverage).
+
+### Error Handling (TypeScript)
+
+- Wrap in `try/catch`, call `toast.error("message")` + `console.error("context:", error)`
+- Extract messages: `e instanceof Error ? e.message : String(e)`
+- `else` and `catch` on new line after closing brace (Allman-ish style)
+
+### Comments and Emojis
+
+- **No comments in code.** Do not add inline comments, block comments, or JSDoc to TypeScript,
+  Svelte, or Rust files. The code should be self-documenting through clear naming.
+- **No emojis in markdown or code.** Never use emoji characters in `.md` files, commit messages,
+  toast messages, log messages, or anywhere else in the codebase.
+
+### Restricted Patterns
+
+- `no-console`: warn (prefer toast for user-facing messages)
+- `node/no-process-env`: error (use Tauri APIs instead)
+- `antfu/no-top-level-await`: off (allowed)
+
+## Code Style - Rust
+
+### Formatting (`rustfmt.toml`)
+
+- Edition 2021, max width 100, 4 spaces, Unix newlines
+
+### Module Organization
+
+- `mod.rs` declares submodules and re-exports public API via `pub use`
+- Private submodules: `mod name;` (no `pub`)
+- Files: **snake_case**; Types: **PascalCase**; Constants: **UPPER_SNAKE_CASE**
+
+### Tauri Commands
+
+- Annotated with `#[tauri::command]`, always return `Result<T, String>`
+- Errors via `.map_err(|e| format!("Descriptive message: {}", e))?`
+- No custom error enums; all errors are `String`-typed
+- Non-critical event emissions: `let _ = app.emit(...);`
+
+### Structs
+
+- Derive `Debug, Clone, serde::Serialize, serde::Deserialize` for data transfer types
+- Use `Option<T>` for optional fields
+
+### Platform-Specific Code
+
+- Use `#[cfg(...)]` for conditional compilation (CUDA/DirectML/CoreML/XNNPACK)
+- Stubs in `onnx_stubs.rs` for unsupported platforms
+
+### Logging
+
+- Use `log::info!`, `log::error!`, etc. (via Tauri log plugin)

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,0 +1,73 @@
+# Hope:RE - Contributing Guide
+
+How to set up, develop, test, commit, and release. For architecture see [CODEBASE.md](CODEBASE.md); for code style see [CODING_CONVENTION.md](CODING_CONVENTION.md).
+
+## Build / Dev / Lint Commands
+
+```bash
+pnpm install              # install frontend dependencies
+pnpm dev                  # start Vite dev server (port 3000)
+pnpm build                # production build (Vite SSG)
+pnpm lint                 # ESLint check (strict, replaces Prettier)
+pnpm format               # ESLint auto-fix
+pnpm check                # svelte-kit sync + svelte-check (type checking)
+pnpm check:watch          # same with --watch
+pnpm tauri dev             # full desktop app dev (Rust + frontend)
+pnpm tauri build           # production desktop build
+```
+
+Rust backend (run from `src-tauri/`):
+
+```bash
+cargo build               # build Rust backend
+cargo check               # type check only
+cargo clippy               # lint Rust code
+cargo fmt                  # format Rust code (rustfmt)
+```
+
+## Testing
+
+No test framework is currently configured. There are no test files in the repo.
+If adding tests, use `vitest` for frontend and `cargo test` for Rust.
+
+## Pre-commit Hooks
+
+Husky runs `lint-staged` on pre-commit which executes `pnpm lint` on all staged files.
+Always run `pnpm lint` before committing.
+
+## Commit Convention
+
+Angular-style conventional commits. Format: `<type>(<scope>): <subject>`
+
+Types: `feat`, `fix`, `perf` (appear in changelog), `build`, `ci`, `docs`, `style`, `refactor`, `test`.
+Subject: imperative present tense, no capital first letter, no trailing period.
+Example: `feat(protection): add nightshade intensity control`
+
+## CI/CD
+
+Full pipeline reference: [CI_CD_PIPELINE.md](CI_CD_PIPELINE.md).
+
+- Lint (`lint.yml`): runs `pnpm lint` on every pull request into `main` (Ubuntu, Node 24, pnpm 11).
+- Release (`publish.yml`): triggered by pushing a version tag matching `v*` (e.g. `v2.5.0`).
+  Builds the multi-platform Tauri bundles (macOS ARM, Windows x64, Linux amd64/arm64),
+  creates the GitHub release named after the tag with notes extracted from the matching
+  `CHANGELOG.md` section, and uploads the ONNX models (Git LFS) to the release.
+
+## Cutting a Release
+
+Releases follow semantic versioning and are driven by `v*` tags, not by pushes to `main`.
+
+1. Bump the version in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`
+   (`hope-ad` package), and `src-tauri/tauri.conf.json`. All four must match.
+2. Add a `## [x.y.z]` section to `CHANGELOG.md`; the workflow extracts the release notes
+   from it (tag `v2.5.0` maps to section `## [2.5.0]`).
+3. Land the bump on `main` through a pull request.
+4. Tag the release commit and push the tag:
+
+```bash
+git tag v2.5.0
+git push origin v2.5.0
+```
+
+The tag push triggers `publish.yml`. Keep the embedded app version in sync with the tag
+so the updater manifest matches the released build.

--- a/CORE_FUNCTION.md
+++ b/CORE_FUNCTION.md
@@ -1,0 +1,61 @@
+# Hope:RE - Core Functions
+
+What the app does and how each feature flows from the Svelte UI through the Tauri command layer into Rust. For the underlying architecture and ONNX pipeline internals see [CODEBASE.md](CODEBASE.md); for code style see [CODING_CONVENTION.md](CODING_CONVENTION.md).
+
+## Tauri Command Surface
+
+All backend calls go through `invoke()` wrappers in `src/lib/queries/` (TanStack Query hooks). Registered commands (`src-tauri/src/lib.rs`):
+
+| Command                      | Input                                  | Output                  | Purpose                                 |
+| ---------------------------- | -------------------------------------- | ----------------------- | --------------------------------------- |
+| `protect_image`              | `imageBase64`, `settings`              | `ProtectionResult`      | Run the protection pipeline             |
+| `cancel_protection`          | none                                   | none                    | Cancel a running protection job         |
+| `embed_watermark`            | `imageBase64`, `watermark`, `seed?`    | signed image (base64)   | Embed a blind watermark                 |
+| `extract_watermark`          | `imageBase64`, `watermarkLen`, `seed?` | extracted text          | Recover an embedded watermark           |
+| `check_models_status`        | none                                   | `ModelsCheckResult`     | Report which ONNX models exist locally  |
+| `download_model`             | `modelName`                            | status string           | Download one ONNX model                 |
+| `get_inference_capabilities` | none                                   | `InferenceCapabilities` | List available execution providers      |
+| `get_system_info`            | none                                   | `SystemInfo`            | CPU/GPU/memory/storage/platform details |
+
+## Image Protection (Cloak Canvas)
+
+Adversarial perturbation that disrupts AI training on the artwork.
+
+- Algorithms: `noise` (adversarial noise), `glaze` (style cloaking with a style index), `nightshade` (data poisoning toward a target concept).
+- UI: `glaze-tab` + `ProtectionMenu` collect algorithm, intensity, output quality, render quality, and the conditional glaze style or nightshade target. `buildProtectionSettings()` normalizes them (intensity slider value divided by 100) into `ProtectionSettings`.
+- Execution: `use-protection.svelte.ts` calls `protect_image` and subscribes to the `protection-progress` event (`stage`, `tile_current`/`tile_total`, `iteration_current`/`iteration_total`, `percent`); stages are `loading`, `processing`, `encoding`, `complete`.
+- Result: `ProtectionResult { image_base64, success, message, model_used }`. When the ONNX models are unavailable the backend falls back to basic protection and `model_used` is `false`; the UI shows a fallback warning.
+- Cancellation: `cancel_protection` stops the run; the store treats user cancellation as a non-error reset.
+
+## Blind Watermarking (Signature Ink)
+
+Frequency-domain signature hiding via the `blind_watermark` crate; robust to cropping, compression, and screenshots.
+
+- Embed (`embed_watermark`): hides UTF-8 signature text, optionally keyed by a numeric seed. The UI records the signature length in UTF-8 bytes and can hand the signed canvas straight to the verifier (`use-watermark-state.svelte.ts` carries image, length, and seed between the two sub-tabs).
+- Extract (`extract_watermark`): recovers `watermarkLen` bytes, optionally with the seed. The frontend validates the result with a printability check (at least 70 percent printable characters) before declaring the signature verified; garbage output is reported as "no valid signature".
+
+## Model Management
+
+The three ONNX models (~350MB each) are not bundled; they are fetched at runtime.
+
+- Source: `https://github.com/HopeArtOrg/hope-re/releases/download` (uploaded by the release pipeline; see [CI_CD_PIPELINE.md](CI_CD_PIPELINE.md)).
+- `check_models_status` reports per-model existence; `ResourceDownloadGuard` wraps the app and auto-starts `download_model` for anything missing, streaming `model-download-progress` events (bytes and percent per model).
+- Storage: `app_data_dir/models/`. Downloads use timeouts, clean up temp files on failure, and the dialog can be minimized to a dock chip while downloads continue.
+
+## Inference Capabilities
+
+`get_inference_capabilities` returns the active ONNX Runtime execution providers for the current platform (CUDA, DirectML, CoreML, XNNPACK, or CPU fallback, selected via `#[cfg(...)]`). The UI surfaces them as a badge next to the protection menu.
+
+## System Info (Studio Vitals)
+
+`get_system_info` gathers OS/hostname, CPU, memory, GPU, storage, and the app version via the `system_info` module; the header dialog renders it with a manual refresh.
+
+## Auto-Update
+
+`tauri-plugin-updater` drives updates: `use-updater.svelte.ts` checks for a newer release, shows the release notes (markdown rendered with `marked` and sanitized with DOMPurify via `parseMarkdown`), then downloads, installs, and relaunches. Active downloads can be minimized to the dock; failures surface in the dialog and as toasts.
+
+## Localization and Theming
+
+- Four locales (`en`, `vi`, `ja`, `zh`) with a header language switcher; every user-facing string resolves through `t()` (rules in [CODING_CONVENTION.md](CODING_CONVENTION.md)).
+- Light/dark/system theme via `use-theme.svelte.ts`.
+- Both preferences persist to the Tauri store file `settings.json`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-re",
   "type": "module",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2283,7 +2283,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-ad"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "base64 0.22.1",
  "blind_watermark",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-ad"
-version = "2.4.0"
+version = "2.5.0"
 description = "An AI-proofing arts app"
 authors = [ "HopeArtOrg" ]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope-RE",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "identifier": "com.HopeArtOrg.hope-re",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Summary

Prepares the 2.5.0 release: switches releases to semver tags, restructures the project documentation, and bumps the version.

### 1. Tag-driven releases (`ci:`)

The `publish` workflow now builds and releases only when a tag matching `v*` is pushed (e.g. `v2.5.0`), instead of on every push to `main`:

- Trigger changed from `push` on `main` to `push` on `tags: ["v*"]`.
- The GitHub release tag and name come from the pushed tag (`github.ref_name`).
- The changelog release-notes lookup strips the leading `v` (tag `v2.5.0` maps to `## [2.5.0]`).
- The ONNX model-upload job targets the same tag. `lint.yml` is unchanged.

### 2. Documentation restructure (`docs:`)

AGENTS.md is now a hub featuring five documents through a documentation map, keeping only the agent tooling tables and a digest of non-negotiable rules:

- `CODEBASE.md` - architecture, project structure, key dependencies, ONNX model pipeline.
- `CORE_FUNCTION.md` - the Tauri command surface and the protection, watermarking, model management, update, and system info flows.
- `CODING_CONVENTION.md` - TypeScript/Svelte, Rust, and i18n coding standards.
- `CONTRIBUTE.md` - build/dev/lint commands, testing, pre-commit hooks, commit convention, CI/CD, and the release checklist.
- `CI_CD_PIPELINE.md` - the lint gate, the tag-driven release build matrix, the model upload job, and required secrets.

The new docs describe the tag-driven release flow, so they land together with the workflow change.

### 3. Version 2.5.0 (`build(release):`)

- `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json` bumped 2.4.0 to 2.5.0, plus the `[2.5.0]` CHANGELOG entry.

## Releasing after this merges

```
git tag v2.5.0
git push origin v2.5.0
```

The tag push triggers the publish workflow; keeping the embedded app version in sync with the tag avoids an updater version mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
