### PR TITLE
fix(android): resolve startup crash (desktop-only plugins + missing rustls crypto provider)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- Prevent the Android app from crashing on launch by registering the desktop-only updater and process plugins under `#[cfg(desktop)]` and scoping their permissions to a desktop-only capability, so they no longer initialize on Android where they are unsupported. The auto-update button is now hidden on mobile.
+
 ## [2.5.0] - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Prevent the Android app from crashing on launch by registering the desktop-only updater and process plugins under `#[cfg(desktop)]` and scoping their permissions to a desktop-only capability, so they no longer initialize on Android where they are unsupported. The auto-update button is now hidden on mobile.
+- Install the rustls `ring` crypto provider at startup so Tauri's internal reqwest client no longer panics with "No provider set" and aborts on Android; reqwest is built without a bundled provider, leaving the choice to the app.
 
 ## [2.5.0] - 2026-07-15
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2293,6 +2293,7 @@ dependencies = [
  "ndarray",
  "ort",
  "reqwest 0.12.28",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-build = { version = "2.6.2", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 log = "0.4"
+rustls = { version = "0.23", default-features = false, features = [ "ring" ] }
 tauri = { version = "2.11.2", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-os = "2.3.2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -22,8 +22,6 @@
     "dialog:allow-save",
     "fs:default",
     "fs:allow-write",
-    "fs:allow-write-file",
-    "updater:default",
-    "process:allow-restart"
+    "fs:allow-write-file"
   ]
 }

--- a/src-tauri/capabilities/desktop.json
+++ b/src-tauri/capabilities/desktop.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "desktop",
+  "description": "desktop-only permissions for in-app auto-update and relaunch",
+  "platforms": [
+    "linux",
+    "macOS",
+    "windows"
+  ],
+  "windows": [
+    "main"
+  ],
+  "permissions": [
+    "updater:default",
+    "process:allow-restart"
+  ]
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,13 +13,20 @@ use commands::{
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
-        .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_process::init())
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_fs::init());
+
+    #[cfg(desktop)]
+    {
+        builder = builder
+            .plugin(tauri_plugin_updater::Builder::new().build())
+            .plugin(tauri_plugin_process::init());
+    }
+
+    builder
         .invoke_handler(tauri::generate_handler![
             get_system_info,
             get_inference_capabilities,
@@ -31,12 +38,15 @@ pub fn run() {
             download_model
         ])
         .setup(|app| {
-            use tauri::Manager;
             #[cfg(not(all(target_os = "android", not(target_arch = "aarch64"))))]
-            app.manage(onnx_integration::protection::ProtectionState::default());
+            {
+                use tauri::Manager;
+                app.manage(onnx_integration::protection::ProtectionState::default());
+            }
 
             #[cfg(target_os = "windows")]
             {
+                use tauri::Manager;
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.set_decorations(false);
                 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,18 +13,18 @@ use commands::{
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let mut builder = tauri::Builder::default()
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init());
 
     #[cfg(desktop)]
-    {
-        builder = builder
-            .plugin(tauri_plugin_updater::Builder::new().build())
-            .plugin(tauri_plugin_process::init());
-    }
+    let builder = builder
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init());
 
     builder
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/system_info/gpu.rs
+++ b/src-tauri/src/system_info/gpu.rs
@@ -6,6 +6,7 @@ struct GpuDetails {
     vram_mb: Option<u64>,
 }
 
+#[cfg(not(all(target_os = "android", not(target_arch = "aarch64"))))]
 pub fn has_nvidia_gpu() -> bool {
     let gpu = detect_gpu();
     gpu.name.to_uppercase().contains("NVIDIA")

--- a/src-tauri/src/system_info/mod.rs
+++ b/src-tauri/src/system_info/mod.rs
@@ -5,7 +5,9 @@ pub mod platform;
 pub mod storage;
 
 pub use cpu::get_cpu_info;
-pub use gpu::{get_gpu_info, has_nvidia_gpu};
+pub use gpu::get_gpu_info;
+#[cfg(not(all(target_os = "android", not(target_arch = "aarch64"))))]
+pub use gpu::has_nvidia_gpu;
 pub use memory::get_memory_info;
 pub use platform::{get_platform_info, PlatformInfo};
 pub use storage::get_storage_info;

--- a/src/lib/components/header/index.svelte
+++ b/src/lib/components/header/index.svelte
@@ -31,7 +31,9 @@
         <span class="text-[9px] opacity-40 font-black uppercase tracking-widest bg-foreground/5 px-2 py-0.5 doodle-line self-center translate-y-0.5">{t("app.studioBadge")}</span>
       </h1>
     </div>
-    <UpdateButton />
+    {#if !isMobile}
+      <UpdateButton />
+    {/if}
     <SystemInfoDialog />
     <LanguageSelect />
     <ThemeToggle />


### PR DESCRIPTION
## Summary

Fixes the Android launch crash. There were **two** distinct crashes, one masking the other; both are fixed here.

### Crash 1 — desktop-only plugins initialized on Android

`tauri-plugin-updater` and `tauri-plugin-process` declare `level = "none"` for Android/iOS. `lib.rs` registered them unconditionally, so they initialized at startup on Android and crashed the app.

- Register `updater`/`process` only under `#[cfg(desktop)]`.
- Move their permissions (`updater:default`, `process:allow-restart`) out of the all-platform `default.json` into a desktop-scoped `desktop.json` capability.
- Hide the auto-update button on mobile (updates come via the app store there).

### Crash 2 — rustls has no crypto provider ("No provider set")

With crash 1 fixed, the app got further and then aborted with a non-unwinding panic:

```
panicked at reqwest-0.13.3/src/async_impl/client.rs:2461:5: No provider set
... Java_..._Rust_handleRequest at wry/src/android/binding.rs:47
thread caused non-unwinding panic. aborting.  → Fatal signal 6 (SIGABRT)
```

Tauri's internal `reqwest` (0.13.3) is built with `rustls-no-provider`, i.e. rustls with **no bundled crypto provider** — by design, the app must install one. The first TLS client Tauri builds on Android (via wry's request handler) therefore panics. reqwest resolves the provider as `CryptoProvider::get_default().unwrap_or_else(default_rustls_crypto_provider)`, and `default_rustls_crypto_provider()` is literally `panic!("No provider set")` when `aws-lc-rs` isn't enabled.

- Add `rustls` (0.23, `ring` feature — already the exact version/provider in the binary) and install it as the process default on the first line of `run()`: `rustls::crypto::ring::default_provider().install_default()`. reqwest's `get_default()` then returns the installed provider and skips the panic.

Also gates `has_nvidia_gpu` to where its only caller compiles, clearing the two dead-code warnings on the x86_64 Android build.

## Verification

- **Exact-panic reproduction on the host:** a minimal `reqwest 0.13.3` + `rustls-no-provider` program panics `at reqwest-0.13.3/src/async_impl/client.rs:2461:5: No provider set` — identical file/line/message to the Android log — and after `rustls::crypto::ring::default_provider().install_default()`, `reqwest::Client::new()` succeeds (exit 0). This reproduces crash 2 and proves the fix.
- `rustls 0.23.39` + `ring` is already compiled into the crashing Android binary; `cargo metadata` adds only the dependency edge (no version churn), so there is no new Android compile risk.
- `rustfmt` clean; frontend `svelte-check` + ESLint pass; PR lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
